### PR TITLE
change row title font style for upcoming sophie-font update

### DIFF
--- a/views/isotype.html
+++ b/views/isotype.html
@@ -2,7 +2,7 @@
   {%- include "./header.html" %} {%- include "./legend.html" %} {% if item.data and item.data.length > 1 %} {%- for row in
   item.data.slice(1) %}
   <div class="q-isotype-row">
-    <div class="q-isotype-row-title s-font-text-s s-font-text-s--strong">{{ row[0] }}</div>
+    <div class="q-isotype-row-title s-font-title-xs">{{ row[0] }}</div>
     {%- if item.options.iconsOneRow%}
       <div class="q-isotype-icon-row">
         {% for value in row %} 


### PR DESCRIPTION
- changes the font class for the row title
- according to https://3.basecamp.com/3500782/buckets/1333489/todos/1352870478 we change the sophie-font class properties for s-font-text-s--strong so the usage in this tool needs to be changed
- The changed here should be deployed to prod once sophie-font is updated, the release procedure is described here: https://github.com/nzzdev/Q-server-nzz/issues/215
- There currently is one piece of the PR in sophie-font (https://github.com/nzzdev/sophie-font/pull/9) missing, therefor it needs to await a merge to master before we can really test this on staging

This can be tested here: https://q.st-test.nzz.ch/item/isotype-15
- the subtitle should be shown in the sans-serif font with font-size: 16px.