### PR TITLE
Move svg definitions out of symbol to support Firefox

### DIFF
--- a/routes/rendering-info/web.js
+++ b/routes/rendering-info/web.js
@@ -83,8 +83,13 @@ function getSvgInfo(svg) {
       renderedSvg.attribs.width && renderedSvg.attribs.height;
     let height;
     let width;
+    // Firefox doesn't support gradient definitions inside symbols. Therefore we move all the definitions outside of the symbol. See bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=353575
+    let svgDefinitions;
 
     try {
+      if ($("svg").has("defs")) {
+        svgDefinitions = $.html("svg > defs");
+      }
       if (hasWidthHeightAttr) {
         height = parseInt(renderedSvg.attribs.height, 10);
         width = parseInt(renderedSvg.attribs.width, 10);
@@ -106,19 +111,22 @@ function getSvgInfo(svg) {
         resolve({
           hasHeight: height !== undefined,
           hasWidth: width !== undefined,
-          aspectRatio: "square"
+          aspectRatio: "square",
+          svgDefinitions: svgDefinitions
         });
       } else if (height > width) {
         resolve({
           hasHeight: height !== undefined,
           hasWidth: width !== undefined,
-          aspectRatio: "vertical"
+          aspectRatio: "vertical",
+          svgDefinitions: svgDefinitions
         });
       } else {
         resolve({
           hasHeight: height !== undefined,
           hasWidth: width !== undefined,
-          aspectRatio: "horizontal"
+          aspectRatio: "horizontal",
+          svgDefinitions: svgDefinitions
         });
       }
     } catch (err) {
@@ -218,6 +226,7 @@ module.exports = {
                 aspectRatios[svgInfo.aspectRatio]++; // count the amount of aspectRatios
                 if (svgInfo.hasHeight || svgInfo.hasWidth) {
                   icon.svg = getCleanedSvg(icon.svg, svgInfo);
+                  icon.svgDefinitions = svgInfo.svgDefinitions;
                 }
               } catch (err) {
                 console.log(err);
@@ -250,9 +259,7 @@ module.exports = {
     };
 
     if (item.allowDownloadData) {
-      context.linkToCSV = `${
-        request.payload.toolRuntimeConfig.toolBaseUrl
-      }/data?appendItemToPayload=${request.query._id}`;
+      context.linkToCSV = `${request.payload.toolRuntimeConfig.toolBaseUrl}/data?appendItemToPayload=${request.query._id}`;
     }
 
     const renderingInfo = {

--- a/views/Legend.svelte
+++ b/views/Legend.svelte
@@ -16,6 +16,9 @@
             class="q-isotype-legend-svg"
             class:q-isotype-lowlight={isLowlight(index + 1)}>
             <svg xmlns="http://www.w3.org/2000/svg">
+              {#if item.icons[index].svgDefinitions}
+                {@html item.icons[index].svgDefinitions}
+              {/if}
               <symbol id={item.icons[index].key}>
                 {@html item.icons[index].svg}
               </symbol>


### PR DESCRIPTION
Firefox doesn't support gradient definitions inside symbols. Therefore we move all the definitions outside of the symbol. See bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=353575